### PR TITLE
docs: fixed CRD name in BGP Control Plane v2

### DIFF
--- a/Documentation/network/bgp-control-plane/bgp-control-plane-v2.rst
+++ b/Documentation/network/bgp-control-plane/bgp-control-plane-v2.rst
@@ -16,7 +16,7 @@ The following resources are used to manage the BGP Control Plane:
 
 * ``CiliumBGPClusterConfig``: Defines BGP instances and peer configurations that are applied to multiple nodes.
 * ``CiliumBGPPeerConfig``: A common set of BGP peering setting. It can be used across multiple peers.
-* ``CiliumBGPAdvertisements``: Defines prefixes that are injected into the BGP routing table.
+* ``CiliumBGPAdvertisement``: Defines prefixes that are injected into the BGP routing table.
 * ``CiliumBGPNodeConfigOverride``: Defines node-specific BGP configuration to provide a finer control.
 
 The relationship between various resources is shown in the below diagram:


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

The CRD kind name of "CiliumBGPAdvertisement" was miswritten in plural type in the document.

```release-note
Fixed BGP documentation
```
